### PR TITLE
Extract variable for VASM executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BINFILES = bin/snake.out bin/vgatest.out bin/piday2021.out bin/vgademo.out
+VASM ?= vasm.vasm6502-oldstyle
 
 all: $(BINFILES)
 
@@ -6,5 +7,5 @@ clean:
 	rm -f $(BINFILES)
 
 bin/%.out: src/%.s src/*.s src/lib/*.s
-	vasm.vasm6502-oldstyle -Fbin -dotdir $< -o $@
+	$(VASM) -Fbin -dotdir $< -o $@
 


### PR DESCRIPTION
I had renamed vasm on my machine. This allow an environment variable to override the default executable name.

Tests:
* `make` with no env variable set runs `vasm.vasm6502-oldstyle`
* `make VASM=vasm.foo` should return a build error
```bash
❯ make VASM=vasm.foo
vasm.foo -Fbin -dotdir src/snake.s -o bin/snake.out
make: vasm.foo: No such file or directory
make: *** [bin/snake.out] Error 1
```